### PR TITLE
fix(zap): Update runs-on to ubuntu-22.04, Add retry mechanism, Modify run-ci command, Remove --wait flag

### DIFF
--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Run image
         run: |
           just run-ci
-          curl --retry 5 --retry-max-time 120 -k -s -o /dev/null -w "%{http_code}" https://127.0.0.1/health
+          curl --retry 5 --retry-connrefused --retry-max-time 120 -k -s https://127.0.0.1/health
 
       - name: ZAP Scan
         uses: zaproxy/action-api-scan@v0.7.0

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -7,7 +7,7 @@ permissions:
   issues: write
 jobs:
   zap_scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Scan the webapplication
     steps:
       - uses: actions/checkout@v4
@@ -15,8 +15,6 @@ jobs:
       # This step builds the image and runs the web application in the background for the ZAP scan
       - name: Run image
         run: |
-          sudo apt update
-          sudo apt install -y docker-compose-v2
           docker-compose --version
           just run-ci
       - name: ZAP Scan

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -19,7 +19,7 @@ jobs:
           # Wait for the web application to start. Retry 5 times every 5 seconds.
           for i in {1..5}; do
             sleep 5
-            response_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8443 || true)
+            response_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8443/health || true)
             if [ $response_code -eq 200 ]; then
               exit 0
             fi

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -2,7 +2,7 @@ name: ZAP Scan
 on:
   push:
     branches:
-      - feat/fix-zap-tests
+      - main
 permissions:
   issues: write
 jobs:
@@ -16,7 +16,7 @@ jobs:
       - name: Run image
         run: |
           just run-ci
-          curl --retry 5 --retry-connrefused --retry-max-time 120 -k -s https://127.0.0.1/health
+          curl --retry 10 --retry-connrefused --retry-max-time 120 -k -s https://127.0.0.1/health
 
       - name: ZAP Scan
         uses: zaproxy/action-api-scan@v0.7.0

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -19,7 +19,7 @@ jobs:
           # Wait for the web application to start. Retry 5 times every 5 seconds.
           for i in {1..5}; do
             sleep 5
-            response_code=$(curl -s -o /dev/null -w "%{http_code}" https://127.0.0.1/health || true)
+            response_code=$(curl -k -s -o /dev/null -w "%{http_code}" https://127.0.0.1/health || true)
             if [ $response_code -eq 200 ]; then
               exit 0
             fi

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -15,8 +15,8 @@ jobs:
       # This step builds the image and runs the web application in the background for the ZAP scan
       - name: Run image
         run: |
-          apt update
-          apt install -y docker.io docker-compose
+          sudo apt update
+          sudo apt install -y docker.io docker-compose
           docker-compose --version
           just run-ci
       - name: ZAP Scan

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -19,7 +19,7 @@ jobs:
           # Wait for the web application to start. Retry 5 times every 5 seconds.
           for i in {1..5}; do
             sleep 5
-            response_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8443/health || true)
+            response_code=$(curl -s -o /dev/null -w "%{http_code}" https://localhost:8443/health || true)
             if [ $response_code -eq 200 ]; then
               exit 0
             fi

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -15,6 +15,8 @@ jobs:
       # This step builds the image and runs the web application in the background for the ZAP scan
       - name: Run image
         run: |
+          sudo apt update
+          sudo apt install -y docker-compose
           docker-compose --version
           just run-ci
       - name: ZAP Scan

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -19,7 +19,10 @@ jobs:
           # Wait for the web application to start. Retry 5 times every 5 seconds.
           for i in {1..5}; do
             sleep 5
-            curl -s -o /dev/null -w "%{http_code}" http://localhost:8443/ && exit 0
+            response_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8443)
+            if [ $response_code -eq 200 ]; then
+              exit 0
+            fi
           done
           exit 1
 

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -19,8 +19,9 @@ jobs:
           # Wait for the web application to start. Retry 5 times every 5 seconds.
           for i in {1..5}; do
             sleep 5
-            curl -s -o /dev/null -w "%{http_code}" http://localhost:8443/ || exit 1
+            curl -s -o /dev/null -w "%{http_code}" http://localhost:8443/ && exit 0
           done
+          exit 1
 
       - name: ZAP Scan
         uses: zaproxy/action-api-scan@v0.7.0

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -16,15 +16,7 @@ jobs:
       - name: Run image
         run: |
           just run-ci
-          # Wait for the web application to start. Retry 5 times every 5 seconds.
-          for i in {1..5}; do
-            sleep 5
-            response_code=$(curl -k -s -o /dev/null -w "%{http_code}" https://127.0.0.1/health || true)
-            if [ $response_code -eq 200 ]; then
-              exit 0
-            fi
-          done
-          exit 1
+          curl --retry 5 --retry-max-time 120 -k -s -o /dev/null -w "%{http_code}" https://127.0.0.1/health
 
       - name: ZAP Scan
         uses: zaproxy/action-api-scan@v0.7.0

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -7,7 +7,7 @@ permissions:
   issues: write
 jobs:
   zap_scan:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     name: Scan the webapplication
     steps:
       - uses: actions/checkout@v4
@@ -15,10 +15,13 @@ jobs:
       # This step builds the image and runs the web application in the background for the ZAP scan
       - name: Run image
         run: |
-          sudo apt update
-          sudo apt install -y docker-compose-v2
-          docker-compose --version
           just run-ci
+          # Wait for the web application to start. Retry 5 times every 5 seconds.
+          for i in {1..5}; do
+            sleep 5
+            curl -s -o /dev/null -w "%{http_code}" http://localhost:8443/ || exit 1
+          done
+
       - name: ZAP Scan
         uses: zaproxy/action-api-scan@v0.7.0
         with:

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -14,7 +14,11 @@ jobs:
       - uses: extractions/setup-just@v2
       # This step builds the image and runs the web application in the background for the ZAP scan
       - name: Run image
-        run: just run-ci
+        run: |
+          apt update
+          apt install -y docker.io docker-compose
+          docker-compose --version
+          just run-ci
       - name: ZAP Scan
         uses: zaproxy/action-api-scan@v0.7.0
         with:

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Run image
         run: |
           sudo apt update
-          sudo apt install -y docker-compose
+          sudo apt install -y docker-compose-v2
           docker-compose --version
           just run-ci
       - name: ZAP Scan

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Run image
         run: |
           sudo apt update
-          sudo apt install -y docker.io docker-compose
+          sudo apt install -y docker-compose
           docker-compose --version
           just run-ci
       - name: ZAP Scan

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -19,7 +19,7 @@ jobs:
           # Wait for the web application to start. Retry 5 times every 5 seconds.
           for i in {1..5}; do
             sleep 5
-            response_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8443)
+            response_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8443 || true)
             if [ $response_code -eq 200 ]; then
               exit 0
             fi

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -2,7 +2,7 @@ name: ZAP Scan
 on:
   push:
     branches:
-      - main
+      - feat/fix-zap-tests
 permissions:
   issues: write
 jobs:

--- a/.github/workflows/zap-scanner.yaml
+++ b/.github/workflows/zap-scanner.yaml
@@ -19,7 +19,7 @@ jobs:
           # Wait for the web application to start. Retry 5 times every 5 seconds.
           for i in {1..5}; do
             sleep 5
-            response_code=$(curl -s -o /dev/null -w "%{http_code}" https://localhost:8443/health || true)
+            response_code=$(curl -s -o /dev/null -w "%{http_code}" https://127.0.0.1/health || true)
             if [ $response_code -eq 200 ]; then
               exit 0
             fi
@@ -31,6 +31,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           format: openapi
-          target: 'https://localhost:8443/openapi.json'
+          target: 'https://127.0.0.1/openapi.json'
           # The '-a' option activates all active scanners. Use this for comprehensive scanning.
           cmd_options: '-a'

--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ run: build
 
 # Use this command to run the application in CI/CD pipeline
 run-ci:
-    docker-compose up -d --wait
+    docker-compose up -d
 
 # Use this command to run the application in development mode in your local machine,
 # using your local source code, without the need to rebuild the image. Don't use it if you're

--- a/justfile
+++ b/justfile
@@ -51,7 +51,7 @@ run: build
     docker run -it -p 5000:5000 -e ENVIRONMENT=development -v $pwd/data:/data test-actions
 
 # Use this command to run the application in CI/CD pipeline
-run-ci: build
+run-ci:
     docker-compose up -d --wait
 
 # Use this command to run the application in development mode in your local machine,


### PR DESCRIPTION
### **Description**
- Updated the `runs-on` value to `ubuntu-22.04` in the `.github/workflows/zap-scanner.yaml` file
- Added a retry mechanism to wait for the web application to start before running ZAP scan in the `.github/workflows/zap-scanner.yaml` file
- Modified the `run-ci` command in the `ZAP Scan` job to remove the `--wait` flag in the `.github/workflows/zap-scanner.yaml` file
- Removed the `--wait` flag from the `run-ci` command in the `justfile`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zap-scanner.yaml</strong><dd><code>Updated runs-on to ubuntu-22.04, Added retry mechanism, Modified </code><br><code>run-ci command</code></dd></summary>
<hr>

.github/workflows/zap-scanner.yaml
['Updated the `runs-on` value to `ubuntu-22.04`', 'Added a retry mechanism to wait for the web application to start before running ZAP scan', 'Modified the `run-ci` command in the `ZAP Scan` job to remove the `--wait` flag']


</details>


  </td>
  <td><a href="https://github.com/manoelhc/test-actions/pull/88/files#diff-19112397a9c861b0f3d264cfbc9d122ada19a58c894eb11ae0c4a1c770ab9cc7">+11/-3</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>justfile</strong><dd><code>Removed --wait flag from run-ci command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

justfile
['Removed the `--wait` flag from the `run-ci` command']


</details>


  </td>
  <td><a href="https://github.com/manoelhc/test-actions/pull/88/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the ZAP Scan GitHub Action workflow to run on a specific feature branch, changes the runner to 'ubuntu-22.04', and adds a step to ensure the web application is running before starting the ZAP scan. Additionally, it modifies the 'justfile' to remove the '--wait' flag from the 'docker-compose up' command in the 'run-ci' task.

* **CI**:
    - Updated the ZAP Scan GitHub Action workflow to run on the 'feat/fix-zap-tests' branch instead of 'main'.
    - Changed the runner for the ZAP Scan job from 'ubuntu-latest' to 'ubuntu-22.04'.
    - Added a step to wait for the web application to start before proceeding with the ZAP scan, including retry logic.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to use `ubuntu-22.04` for better compatibility.
  - Improved ZAP scan workflow by adding a script to ensure the web application starts before scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->